### PR TITLE
Updated line error and File Formats

### DIFF
--- a/ParticleViz_DataPreproc/PreprocParticleViz.py
+++ b/ParticleViz_DataPreproc/PreprocParticleViz.py
@@ -56,6 +56,13 @@ class PreprocParticleViz:
             return ModelType.OPEN_DRIFT
         if np.any([x.find('parcels') != -1 for x in attrs]):
             return ModelType.OCEAN_PARCELS
+        
+        # Heuristics for zarr structure - check variable names
+        var_names = list(xr_ds.variables.keys())
+        if {'obs', 'traj', 'lon', 'lat', 'z', 'time'}.issubset(set(var_names)):
+            return ModelType.OCEAN_PARCELS
+        if {'trajectory', 'time', 'lon', 'lat'}.issubset(set(var_names)):
+            return ModelType.OPEN_DRIFT
         # TODO Throw an exception
 
     def getTotTimeStepsAndNumParticles(self, model_type, xr_ds):

--- a/ParticleViz_WebApp/src/ParticlesLayer.js
+++ b/ParticleViz_WebApp/src/ParticlesLayer.js
@@ -819,6 +819,7 @@ class  ParticlesLayer extends React.Component {
 
         const timestep_idx = timestep_idx_org % this.state.timesteps_per_file
 
+
         if (available_files.includes(file_number)) {
             // Retreive all the information from the first available file
             let drawing_data = this.state.data[model_id][file_number][data_key]
@@ -843,6 +844,11 @@ class  ParticlesLayer extends React.Component {
                             nlat = drawing_data["lat_lon"][0][part_id][timestep_idx + 1]
                             disp_part = drawing_data["disp_info"][part_id][timestep_idx] && drawing_data["disp_info"][part_id][timestep_idx + 1]
 
+                            //Logic for big horizontal lines across the globe
+                            if (disp_part && Math.abs(nlon - clon) > 180) {
+                                continue
+                            }
+                       
                             // do not plot if NaN
                             if(disp_part){
                                 // Here we draw the 'normal' particles, those inside the limits of the globe
@@ -893,6 +899,11 @@ class  ParticlesLayer extends React.Component {
                             clat = drawing_data["lat_lon"][0][part_id][timestep_idx]
                             nlon = drawing_data["lat_lon"][1][part_id][timestep_idx + 1]
                             nlat = drawing_data["lat_lon"][0][part_id][timestep_idx + 1]
+
+                            //Logic for big horizontal lines across the globe
+                            if (Math.abs(nlon - clon) > 180) {
+                                continue
+                            }
 
                             // Here we draw the 'normal' particles, those inside the limits of the globe
                             if ((clon >= this.state.extent[0]) && (clon <= this.state.extent[2])) {


### PR DESCRIPTION
This pull request addresses two issues:

**Fixed Line Error in `drawParticlesAsLines` Function:**
- The condition to check longitude differences across the 180° meridian has been updated. 
- Added a check for disp_part to ensure that the line error is resolved when disp_part is true and longitude differences exceed 180°.
- For cases without NaN values, the check now properly handles longitude differences greater than 180°.

**Fixed File Format Updates in `getOutputType` function:**

- Updated handling for output file formats to ensure compatibility with NetCDF and Zarr.